### PR TITLE
Fix bugs for older Python version(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/pyoae/dsp/processing.py
+++ b/pyoae/dsp/processing.py
@@ -380,9 +380,9 @@ class PulseDpoaeProcessor:
         # rec_lim = axes[0].get_ylim()
         # axes[1].set_ylim(rec_lim)
         axes[0].set_title(
-            f'L1: {self.recording['level1']} dB SPL, '
-            f'L2: {self.recording['level2']} dB SPL, '
-            f'f2: {self.recording['f2']} Hz'
+            f'L1: {self.recording["level1"]} dB SPL, '
+            f'L2: {self.recording["level2"]} dB SPL, '
+            f'f2: {self.recording["f2"]} Hz'
         )
         axes[1].set_title(
             f'Accepted blocks: {self.averager.stats.num_accepted_blocks}'''
@@ -574,9 +574,9 @@ class ContDpoaeProcessor:
         # rec_lim = axes[0].get_ylim()
         # axes[1].set_ylim(rec_lim)
         axes[0].set_title(
-            f'L1: {self.recording['level1']} dB SPL, '
-            f'L2: {self.recording['level2']} dB SPL, '
-            f'f2: {self.recording['f2']} Hz'
+            f'L1: {self.recording["level1"]} dB SPL, '
+            f'L2: {self.recording["level2"]} dB SPL, '
+            f'f2: {self.recording["f2"]} Hz'
         )
         axes[1].set_title(
             f'Accepted blocks: {self.averager.stats.num_accepted_blocks}'''

--- a/pyoae/dsp/processing.py
+++ b/pyoae/dsp/processing.py
@@ -1,7 +1,9 @@
 """Python script to process and visualize a single recording."""
 
 from pathlib import Path
-from typing import TypedDict, cast, NotRequired
+import sys
+from typing import TypedDict, cast
+
 
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
@@ -16,6 +18,12 @@ from pyoae import files
 from pyoae import generator
 from pyoae.calib import MicroTransferFunction
 from pyoae.dsp.opt_avg import OptAverage
+
+
+if sys.version_info >= (3,11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 
 NUM_PTPV_SEGMENTS = 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sounddevice == 0.5.1
 numpy == 2.2.5
 scipy == 1.15.2
 matplotlib == 3.10.1
+typing_extensions == 4.15.0; python_version <= "3.10"


### PR DESCRIPTION
- import NotRequired package from typing_extensions for Python3.10
- generalize venv name in gitignore to venv* to allow suffixes for venv name
- change string delimiter for dictionaries in f-strings from ' to "