### PR TITLE
Zero-signal functionality integrated into Signal class

### DIFF
--- a/device_config.json
+++ b/device_config.json
@@ -7,7 +7,6 @@
     "ramp_duration": 5.0,
     "max_digital_output": 0.5,
     "update_interval": 100.0,
-    "live_display_duration": 10.0,
     "sync_channels": [0, 1],
     "output_input_mapping":[
         [0, 0],

--- a/pyoae/cdpoae.py
+++ b/pyoae/cdpoae.py
@@ -37,7 +37,7 @@ from pyoae.dsp.processing import ContDpoaeProcessor
 from pyoae.generator import ContDpoaeStimulus
 from pyoae.msrmt_context import DpoaeMsrmtContext
 from pyoae.protocols import DpoaeMsrmtParams
-from pyoae.signals import PeriodicRampSignal, ZeroSignal
+from pyoae.signals import PeriodicRampSignal
 from pyoae.sync import (
     get_input_channels,
     HardwareData,
@@ -78,7 +78,7 @@ class DpoaeRecorder:
     msrmt_info: list[ContDpoaeMsrmtInfo]
     """Information of measurements"""
 
-    signals: list[PeriodicRampSignal | ZeroSignal]
+    signals: list[PeriodicRampSignal]
     """List of output signals for each channel."""
 
     msrmt: SyncMsrmt | None
@@ -151,7 +151,7 @@ class DpoaeRecorder:
 
         # Initialize signals
         self.signals = [
-            ZeroSignal() for _ in range(hw_data.get_stream_output_channels())
+            PeriodicRampSignal() for _ in range(hw_data.get_stream_output_channels())
         ]
 
         for i, msrmt_params_i in enumerate(msrmt_params):

--- a/pyoae/cdpoae.py
+++ b/pyoae/cdpoae.py
@@ -102,6 +102,9 @@ class DpoaeRecorder:
         log: Logger | None = None
     ) -> None:
         """Creates a DPOAE recorder for given measurement parameters."""
+
+        # TODO: verify that lists msrmt_params and mic_trans_functions have same lengths
+
         self.logger = log or get_logger()
         self.subject = subject
         self.signals = []

--- a/pyoae/pdpoae.py
+++ b/pyoae/pdpoae.py
@@ -37,7 +37,7 @@ from pyoae.dsp.processing import PulseDpoaeProcessor
 from pyoae.generator import PulseDpoaeStimulus
 from pyoae.msrmt_context import DpoaeMsrmtContext
 from pyoae.protocols import PulseDpoaeMsrmtParams
-from pyoae.signals import PeriodicSignal, ZeroSignal
+from pyoae.signals import PeriodicSignal
 from pyoae.sync import (
     get_input_channels,
     HardwareData,
@@ -78,7 +78,7 @@ class PulseDpoaeRecorder:
     msrmt_infos: list[PulseDpoaeMsrmtInfo]
     """List of measurement information"""
 
-    signals: list[PeriodicSignal | ZeroSignal]
+    signals: list[PeriodicSignal]
     """List of output signals for each channel."""
 
     msrmt: SyncMsrmt | None
@@ -145,7 +145,7 @@ class PulseDpoaeRecorder:
         )
 
         self.signals = [
-            ZeroSignal() for _ in range(hw_data.get_stream_output_channels())
+            PeriodicSignal() for _ in range(hw_data.get_stream_output_channels())
         ]
 
         for i, msrmt_params_i in enumerate(msrmt_params):

--- a/pyoae/signals.py
+++ b/pyoae/signals.py
@@ -1,4 +1,13 @@
-"""Classes to store and manage playback signals."""
+"""Classes to store and manage playback signals.
+
+All classes derived from Signal provide a convenient
+interface with `get_data` for the measurement callback
+of the `sounddevice` package.
+
+If no signal data was provided, i.e., an empty Signal
+object, `get_data` fills the output buffer with zeros
+to provide a mute output signal.
+"""
 
 import numpy as np
 import numpy.typing as npt
@@ -18,10 +27,17 @@ class Signal:
 
     def __init__(
         self,
-        signal_data: npt.NDArray[np.float32]
+        signal_data: npt.NDArray[np.float32] = np.empty(0, dtype=np.float32)
     ) -> None:
         self.signal_data = signal_data
         self.num_signal_samples = len(signal_data)
+
+    def _get_zeros(
+        self,
+        signal_buffer: npt.NDArray[np.float32]
+    ) -> None:
+        """Fills signal buffer with zeros."""
+        signal_buffer[:] = 0
 
     def get_data(
         self,
@@ -29,14 +45,23 @@ class Signal:
         end_idx: int,
         signal_buffer: npt.NDArray[np.float32]
     ) -> bool:
-        """Writes data into the signal buffer and returns output finish flag"""
+        """Writes data into the signal buffer and returns output finish flag."""
+        if self.num_signal_samples == 0:
+            self._get_zeros(signal_buffer)
+            return False
+
         if end_idx < self.num_signal_samples:
             signal_buffer[:] = self.signal_data[start_idx:end_idx]
             return False
-        else:
-            end_len = self.num_signal_samples-start_idx
-            signal_buffer[:end_len] = self.signal_data[start_idx:]
-            return True
+
+        end_len = self.num_signal_samples-start_idx
+        signal_buffer[:end_len] = self.signal_data[start_idx:]
+        return True
+
+    def set_data(self, signal_data: npt.NDArray[np.float32]) -> None:
+        """Sets the data array of the signal."""
+        self.signal_data = signal_data
+        self.num_signal_samples = len(signal_data)
 
 
 class PeriodicSignal(Signal):
@@ -54,8 +79,8 @@ class PeriodicSignal(Signal):
 
     def __init__(
         self,
-        signal_data: npt.NDArray[np.float32],
-        num_total_samples: int
+        signal_data: npt.NDArray[np.float32] = np.empty(0, dtype=np.float32),
+        num_total_samples: int = 0
     ) -> None:
         super().__init__(signal_data)
         self.num_total_samples = num_total_samples
@@ -73,6 +98,10 @@ class PeriodicSignal(Signal):
         Note:
             This overwrites `get_data` from the base class.
         """
+        if self.num_signal_samples == 0:
+            self._get_zeros(signal_buffer)
+            return False
+
         length = end_idx - start_idx
         start_mod = start_idx % self.num_signal_samples
         end_mod = (start_mod + length) % self.num_signal_samples
@@ -91,6 +120,10 @@ class PeriodicSignal(Signal):
         signal_buffer[:] = np.concatenate((tail, head))
         return False
 
+    def set_total_samples(self, num_total_samples: int) -> None:
+        """Sets the number of total samples of the periodic signal."""
+        self.num_total_samples = num_total_samples
+
 
 class PeriodicRampSignal(PeriodicSignal):
     """Periodic signal with fade-in and fade-out ramps."""
@@ -103,9 +136,9 @@ class PeriodicRampSignal(PeriodicSignal):
 
     def __init__(
         self,
-        signal_data: npt.NDArray[np.float32],
-        num_total_samples: int,
-        ramp: npt.NDArray[np.float32]
+        signal_data: npt.NDArray[np.float32] = np.empty(0, dtype=np.float32),
+        num_total_samples: int = 0,
+        ramp: npt.NDArray[np.float32] = np.empty(0, dtype=np.float32)
     ) -> None:
         super().__init__(signal_data, num_total_samples)
         self.ramp = ramp
@@ -118,6 +151,10 @@ class PeriodicRampSignal(PeriodicSignal):
         signal_buffer: npt.NDArray[np.float32]
     ) -> bool:
         """Applies fade-in or fade-out and writes data into signal buffer"""
+        if self.num_signal_samples == 0:
+            self._get_zeros(signal_buffer)
+            return False
+
         is_finished = super().get_data(start_idx, end_idx, signal_buffer)
 
         # Apply fade-in
@@ -145,20 +182,7 @@ class PeriodicRampSignal(PeriodicSignal):
 
         return is_finished
 
-class ZeroSignal(Signal):
-    """Class that always returns zero signals"""
-
-    def __init__(self):
-        super().__init__(np.array(0, dtype=np.float32))
-        self.num_signal_samples = 0
-    def get_data(
-        self,
-        start_idx: int,
-        end_idx: int,
-        signal_buffer: npt.NDArray[np.float32]
-    ) -> bool:
-        """Returns zero filled signal buffer"""
-        del start_idx
-        del end_idx
-        signal_buffer[:] = 0
-        return False
+    def set_ramp(self, ramp: npt.NDArray[np.float32]) -> None:
+        """Sets the data for the fade-in and fade-out ramps."""
+        self.ramp = ramp
+        self.idx_fade_out = self.num_total_samples - len(ramp)

--- a/pyoae/soae.py
+++ b/pyoae/soae.py
@@ -39,7 +39,7 @@ from pyoae.dsp import averaging
 from pyoae.device.device_config import DeviceConfig
 from pyoae.msrmt_context import MsrmtContext
 from pyoae.protocols import MsrmtParams
-from pyoae.signals import ZeroSignal
+from pyoae.signals import Signal
 from pyoae.sync import (
     get_input_channels,
     HardwareData,
@@ -128,7 +128,7 @@ class SoaeRecorder:
 
     msrmt_ctx: MsrmtContext
 
-    signals: list[ZeroSignal]
+    signals: list[Signal]
     """List of output signals for each channel
 
     These are mute signals for SOAE acquisition.
@@ -206,7 +206,7 @@ class SoaeRecorder:
         )
 
         self.signals = [
-            ZeroSignal() for _ in range(hw_data.get_stream_output_channels())
+            Signal() for _ in range(hw_data.get_stream_output_channels())
         ]
 
         self.msrmt = SyncMsrmt(

--- a/pyoae/sync.py
+++ b/pyoae/sync.py
@@ -507,8 +507,8 @@ class SyncMsrmt(Generic[SignalT]):
         input_data: npt.NDArray[np.floating],
         output_data: npt.NDArray[np.floating],
         frames: int,
-        time: Any,
-        status: sd.CallbackFlags
+        time: Any,  # pylint: disable=unused-argument
+        status: sd.CallbackFlags  # pylint: disable=unused-argument
     ) -> None:
         """Callback for the measurement
 
@@ -525,8 +525,8 @@ class SyncMsrmt(Generic[SignalT]):
             status: Status containing information about the callback
 
         """
-        del time
-        del status
+        # del time
+        # del status
 
         # Set the end of the measurement index for this callback
         start_idx = self.live_msrmt_data.play_idx


### PR DESCRIPTION
In order to avoid having multiple `Signal` types within a single `signals` list in the Recorder objects and to improve the `get_data` interface, the zero-signal functionality was integrated into the `Signal` class and its children classes.

New behavior: all `Signal` classes are now being initialized with empty arrays. If a signal is empty, it will fill the requested output buffer with zeros to mute the output by default.

_Please review the proposed changes, particularly with respect to the initialization of the output channels for the bilateral output._

Note: deleting unused arguments to avoid them being flagged by a linter is considered suboptimal style and may result in undefined behavior when deleting objects.